### PR TITLE
commsgaze: Fix first run wait

### DIFF
--- a/ProjectSpace/commsgaze/src/main/java/com/pwc/commsgaze/LoadingViewModel.java
+++ b/ProjectSpace/commsgaze/src/main/java/com/pwc/commsgaze/LoadingViewModel.java
@@ -9,15 +9,26 @@ import androidx.lifecycle.ViewModel;
 public class LoadingViewModel extends ViewModel {
 
     private MutableLiveData<Boolean> isFirstRun;
+    private MutableLiveData<Boolean> cameraPermissionGranted;
+
     private static final String TAG = "LoadingViewModel";
     /*Check on UI thread for shared preference before calling this*/
     LiveData<Boolean> getIsFirstRun() {
         if (isFirstRun == null) {
-            isFirstRun = new MutableLiveData<Boolean>();
-            isFirstRun.setValue(true);
+            isFirstRun = new MutableLiveData<>(true);
             Log.d(TAG,"getIsFirstRunCalled");
         }
         return isFirstRun;
+    }
+    LiveData<Boolean> getCameraPermissionGranted(){
+        if(cameraPermissionGranted==null){
+            cameraPermissionGranted = new MutableLiveData<>(false);
+        }
+        return  cameraPermissionGranted;
+    }
+
+    void cameraPermissionGranted(){
+        cameraPermissionGranted.setValue(true);
     }
 
     public void initialisationDone() {

--- a/ProjectSpace/commsgaze/src/main/java/com/pwc/commsgaze/MainActivity.java
+++ b/ProjectSpace/commsgaze/src/main/java/com/pwc/commsgaze/MainActivity.java
@@ -5,6 +5,7 @@ import android.animation.Animator;
 import android.animation.ValueAnimator;
 import android.os.Bundle;
 import android.os.Handler;
+import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.View;
 import android.widget.Button;
@@ -47,7 +48,7 @@ public class MainActivity extends AppCompatActivity implements CameraBridgeViewB
     private static final String TAG = "MainActivity";
     private MainRecyclerViewAdapter recyclerViewAdapter;
     private RecyclerView.LayoutManager gridLayoutManager;
-    private final int RC_FIXED_DIMENSION = 3;
+    private final int RV_FIXED_DIMENSION = 3;
     private StorageViewModel storageViewModel;
     private  final int SELECTION_THRESHOLD = 15;
     private final int CLICK_INIT_THRESHOLD = 5;
@@ -69,12 +70,14 @@ public class MainActivity extends AppCompatActivity implements CameraBridgeViewB
         storageViewModel = new ViewModelProvider(this).get(StorageViewModel.class);
 
 
-        recyclerViewAdapter = new MainRecyclerViewAdapter( (int)getResources().getDimension(R.dimen.size_main_image),RC_FIXED_DIMENSION);
-        gridLayoutManager = new GridLayoutManager(this,RC_FIXED_DIMENSION,GridLayoutManager.VERTICAL,false);
+        recyclerViewAdapter = new MainRecyclerViewAdapter((int) getResources().getDimension(R.dimen.size_main_image));
+        Log.d(TAG,"RV width "+  binding.mainRecyclerView.getWidth());
+
+        gridLayoutManager = new GridLayoutManager(this, RV_FIXED_DIMENSION,GridLayoutManager.VERTICAL,false);
 
         binding.mainRecyclerView.setLayoutManager(gridLayoutManager);
         binding.mainRecyclerView.setAdapter(recyclerViewAdapter);
-        mainViewModel.initialiseViewGazeHolders(RC_FIXED_DIMENSION,0);
+        mainViewModel.initialiseViewGazeHolders(RV_FIXED_DIMENSION,0);
         mainViewModel.initialiseDirectionMediator(SELECTION_THRESHOLD, CLICK_INIT_THRESHOLD);
 
 
@@ -87,7 +90,7 @@ public class MainActivity extends AppCompatActivity implements CameraBridgeViewB
             public void onChanged(List<Content> contents) {
                 Log.d(TAG,"Changed "+ contents.toString());
                 recyclerViewAdapter.setContents(contents);
-                mainViewModel.initialiseViewGazeHolders(RC_FIXED_DIMENSION,contents.size());
+                mainViewModel.initialiseViewGazeHolders(RV_FIXED_DIMENSION,contents.size());
             }
         });
 
@@ -246,6 +249,8 @@ public class MainActivity extends AppCompatActivity implements CameraBridgeViewB
                 }
             });
 
+
+
         }
     }
 
@@ -257,8 +262,8 @@ public class MainActivity extends AppCompatActivity implements CameraBridgeViewB
         /*configs go away when app activity is re-opened*/
         hideSystemUI();
         binding.openCVCameraView.enableView();
-
     }
+
 
     /*Hides System UI
      * https://developer.android.com/training/system-ui/immersive.html*/
@@ -309,7 +314,6 @@ public class MainActivity extends AppCompatActivity implements CameraBridgeViewB
     }
 
 
-
     private void initialiseApproach(Approach approach){
         if(approach.equals(Approach.OPENCV_SPARSE_FLOW) ){
             /*TODO We need to only activate this if the user has set for an approach which uses opencv -- most prolly use the stored data on the approach to check  first */
@@ -350,4 +354,9 @@ public class MainActivity extends AppCompatActivity implements CameraBridgeViewB
     public void enterClicked(View view) {
         /*TODO*/
     }
+
+
+
+
+
 }

--- a/ProjectSpace/commsgaze/src/main/java/com/pwc/commsgaze/MainRecyclerViewAdapter.java
+++ b/ProjectSpace/commsgaze/src/main/java/com/pwc/commsgaze/MainRecyclerViewAdapter.java
@@ -3,7 +3,6 @@ package com.pwc.commsgaze;
 import android.media.AudioAttributes;
 import android.media.MediaPlayer;
 import android.net.Uri;
-import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -28,15 +27,14 @@ public class MainRecyclerViewAdapter extends RecyclerView.Adapter<MainRecyclerVi
     public final static String TAG = "MainRecyclerViewAdapter";
     private List<Content> contents;
 
-    private int imageSize;
-    private int fixedDimension;
-
-    MainRecyclerViewAdapter(int imageSize,int fixedDimension){
-        this.imageSize = imageSize;
-        this.fixedDimension = fixedDimension;
+    private int suitableItemSize;
 
 
+    MainRecyclerViewAdapter(int suitableItemSize){
+        Log.d(TAG,"Device Dimension "+ suitableItemSize);
+        this.suitableItemSize = suitableItemSize;
     }
+
 
     @NonNull
     @Override
@@ -56,7 +54,7 @@ public class MainRecyclerViewAdapter extends RecyclerView.Adapter<MainRecyclerVi
         Uri imageUri = Uri.fromFile(new File(contents.get(position).getImageDirPath()));
         Glide.with(holder.itemView.getContext())
                 .load(imageUri)
-                .apply(new RequestOptions().override(imageSize,imageSize))
+                .apply(new RequestOptions().override(suitableItemSize, suitableItemSize))
                 .into(holder.imageView);
 
         holder.setAudioDirPath(contents.get(position).getAudioDirPath());
@@ -130,5 +128,6 @@ public class MainRecyclerViewAdapter extends RecyclerView.Adapter<MainRecyclerVi
             }
         }
     }
+
 
 }


### PR DESCRIPTION
commsgaze:Further fixes to first time init issue

The first time initialisation does not confirms on whether the user has allowed the app to use the camera. After the initialisation has been done, the app will straight go into the MainActivity while the camera being blocked. This situation will occur when the user has not given permission before the completion of the intialisation process.

commsgaze:Added snackbar to prompt user to grant camera permission